### PR TITLE
[Feature] - Meta column translator

### DIFF
--- a/lib/decidim_metabase/main.rb
+++ b/lib/decidim_metabase/main.rb
@@ -6,8 +6,14 @@ module DecidimMetabase
   # Main - Main structure to work with Metabase
   # Define connexion, session, http requests, databases, cards actions
   class Main
-    attr_accessor :configs, :databases, :metabase_collection, :metabase_cards, :metabase_api_collection,
-                  :filesystem_collection, :api_cards
+    attr_accessor :configs,
+                  :databases,
+                  :metabase_collection,
+                  :metabase_cards,
+                  :metabase_api_collection,
+                  :filesystem_collection,
+                  :api_cards
+
     attr_reader :db_registry
 
     def initialize(welcome)
@@ -130,8 +136,12 @@ module DecidimMetabase
         puts "Updating card '#{card.name}' (#{db.type} - ID/#{card.id}) with URL : #{metabase_url}question/#{card.id}"
           .colorize(:light_yellow)
         updated = @api_cards.update(card)
-        puts "Card successfully updated (#{db.type} - ID/#{updated["id"]})".colorize(:light_green)
 
+        if updated.include?("errors")
+          puts "[CARD '#{card.name}'] - #{updated["errors"].first}".colorize(:red)
+        else
+          puts "Card successfully updated (#{db.type} - ID/#{updated["id"]})".colorize(:light_green)
+        end
         card.update_id!(updated["id"]) if card.id != updated["id"]
       when :create
         puts "Creating card '#{card.name}'".colorize(:light_green)
@@ -157,7 +167,7 @@ module DecidimMetabase
         if db.nil?
           puts "[DatabaseNotFound] - #{card.cards_name} - Database not found for card '#{card.name}'
 Ensure your 'config.yml' contains the key '#{card.cards_name}' for the target database
-Database key '#{card.cards_name}' is not included in : #{@databases.map(&:type) }
+Database key '#{card.cards_name}' is not included in : #{@databases.map(&:type)}
 
 Note: Your database key must match exactly the cards folder name under './cards/*'
 ".colorize(:yellow)
@@ -165,6 +175,7 @@ Note: Your database key must match exactly the cards folder name under './cards/
           next
         end
 
+        card.meta_columns_payload(online_card&.result_metadata)
         card.build_payload!(@metabase_collection, db.id, all_cards)
         action_for(card, db)
       end

--- a/lib/decidim_metabase/main.rb
+++ b/lib/decidim_metabase/main.rb
@@ -85,16 +85,12 @@ module DecidimMetabase
     # It registers the cards present in Metabase in the metabase_collection.cards
     def set_collections!
       prepare_metabase_collection!
-      set_metabase_cards!
+      metabase_cards = fetch_metabase_cards
       set_filesystem_collection!
 
       @metabase_collection = DecidimMetabase::Object::Collection.new(@metabase_api_collection).tap do |obj|
-        obj.cards_from!(@metabase_cards.cards)
+        obj.cards_from!(metabase_cards.cards)
       end
-
-      # Metabase cards depends on cards in Metabase.
-      # Better for memory to remove the variable once we store the cards we need
-      remove_instance_variable(:@metabase_cards)
 
       load_all_fs_cards!
       @metabase_collection.define_resource(@filesystem_collection)
@@ -107,8 +103,8 @@ module DecidimMetabase
     end
 
     # Define @metabase_cards from the cards fetched from Metabase
-    def set_metabase_cards!
-      @metabase_cards = DecidimMetabase::Api::Card.new(@http_request)
+    def fetch_metabase_cards
+      DecidimMetabase::Api::Card.new(@http_request)
     end
 
     # Define @filesystem_collection from the collection fetched from Metabase

--- a/lib/decidim_metabase/main.rb
+++ b/lib/decidim_metabase/main.rb
@@ -92,6 +92,10 @@ module DecidimMetabase
         obj.cards_from!(@metabase_cards.cards)
       end
 
+      # Metabase cards depends on cards in Metabase.
+      # Better for memory to remove the variable once we store the cards we need
+      remove_instance_variable(:@metabase_cards)
+
       load_all_fs_cards!
       @metabase_collection.define_resource(@filesystem_collection)
     end

--- a/lib/decidim_metabase/main.rb
+++ b/lib/decidim_metabase/main.rb
@@ -154,7 +154,16 @@ module DecidimMetabase
         card.update_id!(online_card.id) if online_card&.id
         card.need_update = online_card&.query != card.query
         db = find_db_for(card)
-        next if db.nil?
+        if db.nil?
+          puts "[DatabaseNotFound] - #{card.cards_name} - Database not found for card '#{card.name}'
+Ensure your 'config.yml' contains the key '#{card.cards_name}' for the target database
+Database key '#{card.cards_name}' is not included in : #{@databases.map(&:type) }
+
+Note: Your database key must match exactly the cards folder name under './cards/*'
+".colorize(:yellow)
+
+          next
+        end
 
         card.build_payload!(@metabase_collection, db.id, all_cards)
         action_for(card, db)

--- a/lib/decidim_metabase/object/card.rb
+++ b/lib/decidim_metabase/object/card.rb
@@ -5,7 +5,7 @@ module DecidimMetabase
     # Metabase card
     class Card
       attr_accessor :id, :name, :description, :archived, :collection_position, :table_id, :database_id, :collection_id,
-                    :query_type, :creator, :collection, :dataset_query, :need_update, :exist, :resource
+                    :query_type, :creator, :collection, :dataset_query, :need_update, :exist, :resource, :result_metadata
 
       def initialize(hash, exist = true)
         @id = hash["id"]
@@ -20,6 +20,7 @@ module DecidimMetabase
         @creator = hash["creator"]
         @collection = DecidimMetabase::Object::Collection.new(hash["collection"])
         @dataset_query = hash["dataset_query"]
+        @result_metadata = hash["result_metadata"]
         @need_update = false
         @exist = exist
       end

--- a/lib/decidim_metabase/object/collection.rb
+++ b/lib/decidim_metabase/object/collection.rb
@@ -30,11 +30,9 @@ module DecidimMetabase
       def cards_from(api_cards)
         @cards = api_cards.map do |card|
           next if card["collection"].nil? || card["collection"].empty?
+          next unless card["collection_id"] == @id
 
-          obj = DecidimMetabase::Object::Card.new(card, false)
-          next unless obj&.collection_id == @id
-
-          obj
+          DecidimMetabase::Object::Card.new(card, false)
         end.compact
       end
 

--- a/main.rb
+++ b/main.rb
@@ -8,7 +8,6 @@ require "faraday/net_http"
 require "dotenv/load"
 require "yaml"
 require "colorize"
-require "byebug"
 
 Faraday.default_adapter = :net_http
 main = DecidimMetabase::Main.new(true)

--- a/main.rb
+++ b/main.rb
@@ -8,6 +8,7 @@ require "faraday/net_http"
 require "dotenv/load"
 require "yaml"
 require "colorize"
+require "byebug"
 
 Faraday.default_adapter = :net_http
 main = DecidimMetabase::Main.new(true)


### PR DESCRIPTION
### Description

This PR aims to translate automatically the columns name of your models.

### Notes

By default, translations are skipped if there is no defined translation. If the column doesn't exist, it is also skipped.

In the locales of your cards, you must define translation as below : 
```yaml
# file decidim_cards/organizations/locales/en.yml

---
[...]
meta:
  columns:
    id: ID
    name: Name
    host: Host
```

**ALSO :** At the moment translations can't be set on creation, however you can rerun the program and it will detect changes in columns name

### Tasks 

- [x] Handle error when database is unknown
- [x] Handle error on card update / creation
- [x] Add translation system