### PR TITLE
Feature/add description into models

### DIFF
--- a/lib/decidim_metabase/object/filesystem_card.rb
+++ b/lib/decidim_metabase/object/filesystem_card.rb
@@ -63,15 +63,20 @@ module DecidimMetabase
       def meta_columns_payload(result_metadata)
         return if result_metadata.nil?
 
-        @result_metadata = result_metadata.map do |meta|
-          next unless t_meta_columns.include?(meta["field_ref"][1])
+        @result_metadata = result_metadata.map do |column|
+          next unless t_meta_columns.include?(column["field_ref"][1])
 
-          if meta["display_name"] != t_meta_columns[meta["name"]]
-            meta["display_name"] = t_meta_columns[meta["name"]]
+          if column["display_name"] != t_meta_columns[column["name"]]["name"]
+            column["display_name"] = t_meta_columns[column["name"]]["name"]
+            @need_update ||= true
+          end
+          
+          if column["description"] != t_meta_columns[column["name"]]["description"]
+            column["description"] = t_meta_columns[column["name"]]["description"]
             @need_update ||= true
           end
 
-          meta
+          column
         end.compact
       end
 


### PR DESCRIPTION
After setting up the title of the column in the locale we want, it could be great to set up the description of the columns, in order to help users knowing what each column contain.

Currently, the work done implies to change the locales files from this
```yml
...
meta:
  columns:
    id: ID
    name: Name
...
```
to this

```yml
...
meta:
  columns:
    id: 
      name: ID
      description: ID of the organization
    name:
      name: blabla
      description: the name description
    host: Host
...
```

As it may seems really verbose, it's (in my opinion) the last change in the architecture of Yaml files, since it's open to welcome other attributes that  may arrive after : mapping to database column, type of the column, etc.

- [ ] Add test for change title and description